### PR TITLE
use [AUDIENCE] GcpAuthnFilterConfig uri

### DIFF
--- a/envoy-cloudrun-proxy/envoy.yaml
+++ b/envoy-cloudrun-proxy/envoy.yaml
@@ -63,7 +63,7 @@ static_resources:
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.gcp_authn.v3.GcpAuthnFilterConfig          
                     http_uri: 
-                      uri: "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://<service_id>.a.run.app"
+                      uri: "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=[AUDIENCE]"
                       cluster: gcp_metadata_server
                       timeout: 1s
                 - name: envoy.filters.http.router


### PR DESCRIPTION
The actual value for the target cluster is taken from the cluster metadata:

https://github.com/envoyproxy/envoy/blob/b5e3ec9900011d04b08e5dc61c6ee6edd1b2a38f/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc#L71-L77